### PR TITLE
Refactor: changing 'gameOver' status, move class MineTile into a seperate file

### DIFF
--- a/MineSweeper.java
+++ b/MineSweeper.java
@@ -3,21 +3,11 @@ import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.Random;
 import javax.swing.*;
-import javax.swing.border.Border;
+
 
 public class MineSweeper {
     //this class is created because we need to add more properties to the clickable JButtons on grid
     //such as the row and col number of it to know where the button is when clicking it
-    public class MineTile extends JButton {
-        int r;
-        int c;
-
-        public MineTile(int r, int c) {
-            //passes in row & col numbers and assigns them to the member variables
-            this.r = r;
-            this.c = c;
-        }
-    }
 
     int tileSize = 70;
     int numRows = 8;
@@ -78,15 +68,19 @@ public class MineSweeper {
 
                 //set false to let the tile unable to receive keyboard input
                 tile.setFocusable(false);
-                //?set tile margin compare to the numbers/emoji within it
+                //set tile margin compare to the numbers/emoji within it
                 tile.setMargin(new Insets(0, 0, 0, 0));
                 tile.setFont(new Font("Arial Unicode MS", Font.PLAIN, 45));
-//                tile.setText("1");
+                //tile.setText("1");
                 //listens to mouse click
                 tile.addMouseListener(new MouseAdapter() {
                     @Override
                     //runs when mouse is clicked
                     public void mousePressed(MouseEvent e) {
+
+                        if(gameOver){ //check if the game is over or not, if yes then stop the game
+                            return;
+                        }
                         //get the clicked tile by getting a mouse click event
                         MineTile tile = (MineTile) e.getSource();
 
@@ -158,6 +152,9 @@ public class MineSweeper {
         for (MineTile tile : mineList) {
             tile.setText("💣");
         }
+
+        gameOver=true;//this is trigger only if revealMines method is called
+        textLabel.setText("Game Over");//set the notification
     }
 
     void checkMine(int r, int c) {

--- a/MineTile.java
+++ b/MineTile.java
@@ -1,0 +1,12 @@
+import javax.swing.*;
+
+public class MineTile extends JButton {
+    int r;
+    int c;
+
+    public MineTile(int r, int c) {
+        //passes in row & col numbers and assigns them to the member variables
+        this.r = r;
+        this.c = c;
+    }
+}


### PR DESCRIPTION
Moving class MineTile into a seperate file for managing classes, applying design pattern. 
Adding checking 'gameOver' status when a Tile is pressed. 
Before: when clicked on a Mine, the game is still running even though all the mine has been revealed. The other tile can still be clicked.
After: when clicked on a Mine, reveal the Mine, all the Tiles can not be clicked, set the Text to "Game Over" to notify the player.